### PR TITLE
Exposed site SEO data through Conent API & {{@site.*}} helper (#10925)

### DIFF
--- a/core/server/services/settings/public.js
+++ b/core/server/services/settings/public.js
@@ -18,5 +18,13 @@ module.exports = {
     active_timezone: 'timezone',
     ghost_head: 'ghost_head',
     ghost_foot: 'ghost_foot',
-    navigation: 'navigation'
+    navigation: 'navigation',
+    meta_title: 'meta_title',
+    meta_description: 'meta_description',
+    og_image: 'og_image',
+    og_title: 'og_title',
+    og_description: 'og_description',
+    twitter_image: 'twitter_image',
+    twitter_title: 'twitter_title',
+    twitter_description: 'twitter_description'
 };

--- a/core/test/acceptance/old/content/settings_spec.js
+++ b/core/test/acceptance/old/content/settings_spec.js
@@ -43,6 +43,7 @@ describe('Settings Content API', function () {
 
                 // Verify we have the right keys for settings
                 settings.should.have.properties(_.values(publicSettings));
+                Object.keys(settings).length.should.equal(22);
 
                 // Verify that we are returning the defaults for each value
                 _.forEach(settings, (value, key) => {


### PR DESCRIPTION
refs #10921

- Site SEO data will now be available as part of `GET /settings` response in Content API as well as part of {{@site.*}} helper

Got some code for us? Awesome 🎊!

Please include a description of your change & check your PR against this list, thanks!

- [ ] There's a clear use-case for this code change
- [ ] Commit message has a short title & references relevant issues
- [ ] The build will pass (run `yarn test` and `yarn lint`)

More info can be found by clicking the "guidelines for contributing" link above.
